### PR TITLE
Add example for `CursorPagination::make($this->id())` to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file. This projec
 
 - Upgrade to Laravel 10 and set minimum PHP version to 8.1.
 - **BREAKING**: The schema's id field must now always be provided to the `CursorPagination::make()` method and/or
-  constructor.
+  constructor. I.e. use `CursorPagination::make($this->id())`
 
 ## [2.1.0] - 2023-01-24
 


### PR DESCRIPTION
It took us a while to figure out what you meant with "The schema's id field must now always be provided to the `CursorPagination::make()` method and/or constructor.". In https://github.com/laravel-json-api/laravel/blob/develop/CHANGELOG.md#300---2023-02-14 we eventually found an example, so I added it here too for future reference.